### PR TITLE
Add industrial-themed Flask delivery tracker

### DIFF
--- a/tracker/.gitignore
+++ b/tracker/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+instance/
+.env
+.venv/
+data/*.sqlite3
+data/*.db

--- a/tracker/README.md
+++ b/tracker/README.md
@@ -1,0 +1,98 @@
+# Liefer-Tracker
+
+Industrial dark-theme Flask-Anwendung für das Scannen, Nachverfolgen und Priorisieren von Lieferungen auf einem Raspberry Pi.
+
+## Features
+
+- Benutzer-Login ohne Passwort mit Geräte-Token (HttpOnly Cookie)
+- Rollenmodell (`admin`, `contrib`, `viewer`) mit differenzierten Berechtigungen
+- Lieferübersicht mit Filter- & Suchfunktionen sowie Prioritäts-Board
+- Ereignis-Timeline je Lieferung inkl. Notizen, Station- & Versandänderungen
+- Admin-Tools zur Verwaltung von Stationen, Nutzern und registrierten Geräten
+- CSV-Export nach Fälligkeitsstatus
+- Touchfreundliches, dunkles UI mit gelben Akzenten und akustischem Feedback
+
+## Installation
+
+```bash
+sudo apt update && sudo apt install python3-venv git -y
+cd /opt
+sudo git clone <REPO_URL> liefer-tracker
+cd liefer-tracker/tracker
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+flask --app app init-db
+```
+
+Standardnutzer nach Initialisierung:
+
+- `admin` (admin)
+- `halle` (contrib)
+- `buero` (viewer)
+
+Beispielstationen werden automatisch angelegt.
+
+## Entwicklung / Start
+
+```bash
+source .venv/bin/activate
+flask --app app run --debug
+```
+
+Produktionsbetrieb (Gunicorn):
+
+```bash
+source /opt/liefer-tracker/tracker/.venv/bin/activate
+gunicorn -w 2 -b 0.0.0.0:8000 app:app
+```
+
+## systemd-Service (Beispiel)
+
+```
+[Unit]
+Description=Liefer Tracker
+After=network.target
+
+[Service]
+User=pi
+Group=pi
+WorkingDirectory=/opt/liefer-tracker/tracker
+Environment="FLASK_APP=app"
+Environment="TRACKER_SECRET=wechselmich"
+ExecStart=/opt/liefer-tracker/tracker/.venv/bin/gunicorn -w 2 -b 0.0.0.0:8000 app:app
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Nginx-Proxy Snippet
+
+```
+server {
+    listen 80;
+    server_name tracker.internal;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+## Backup-Hinweis
+
+Das SQLite-DB-File liegt unter `tracker/data/tracker.sqlite3`. Für ein Backup reicht das Kopieren des gesamten `data/`-Ordners.
+
+## Smoke-Test
+
+1. Anwendung starten und als `halle` anmelden.
+2. Drei Lieferscheine scannen: `LS-1001`, `LS-1002`, `LS-1003`.
+3. Setze für `LS-1001` das Versanddatum auf heute, für `LS-1002` auf gestern, `LS-1003` auf nächste Woche.
+4. Öffne die Versandübersicht (`/shipping`) und prüfe, dass die drei Lieferungen den erwarteten Fälligkeitsstatus anzeigen (Heute, Überfällig, Diese Woche).
+

--- a/tracker/__init__.py
+++ b/tracker/__init__.py
@@ -1,0 +1,2 @@
+"""Package initialisation for the delivery tracker."""
+from .app import app, create_app  # noqa: F401

--- a/tracker/app.py
+++ b/tracker/app.py
@@ -1,0 +1,485 @@
+"""Main application module for the delivery tracker."""
+from __future__ import annotations
+
+import csv
+import io
+import os
+from datetime import date
+from pathlib import Path
+
+from flask import Flask, Response, flash, g, redirect, render_template, request, url_for
+from flask_wtf import CSRFProtect
+from sqlalchemy import desc, nullslast
+
+from flask import Blueprint
+
+from .auth import auth_bp
+from .forms import (
+    DeleteForm,
+    DeliveryNoteForm,
+    DeliveryPriorityForm,
+    DeliverySearchForm,
+    DeliveryShipDateForm,
+    DeliveryStationForm,
+    DeviceLabelForm,
+    RevokeDeviceForm,
+    ScanForm,
+    StationForm,
+    UserForm,
+)
+from .models import Delivery, Event, EventType, Role, Station, User, db, init_db
+from .utils import (
+    due_badge_class,
+    determine_due_status,
+    eta_for_station,
+    markdown_safe,
+    pagination_range,
+    priority_badge,
+    role_required,
+)
+
+
+BASE_DIR = Path(__file__).resolve().parent
+DB_PATH = BASE_DIR / "data" / "tracker.sqlite3"
+
+
+main_bp = Blueprint("main", __name__)
+admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
+
+
+def create_app() -> Flask:
+    app = Flask(__name__, template_folder="templates", static_folder="static")
+    app.config.setdefault("SECRET_KEY", os.environ.get("TRACKER_SECRET", "change-me"))
+    app.config.setdefault("SQLALCHEMY_DATABASE_URI", f"sqlite:///{DB_PATH}")
+    app.config.setdefault("SQLALCHEMY_TRACK_MODIFICATIONS", False)
+    app.config.setdefault("SESSION_COOKIE_SECURE", False)
+
+    CSRFProtect(app)
+    db.init_app(app)
+
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(main_bp)
+    app.register_blueprint(admin_bp)
+
+    register_cli(app)
+
+    @app.context_processor
+    def inject_helpers() -> dict:
+        return {
+            "markdown_safe": markdown_safe,
+            "determine_due_status": determine_due_status,
+            "due_badge_class": due_badge_class,
+            "priority_badge": priority_badge,
+            "eta_for_station": eta_for_station,
+        }
+
+    return app
+
+
+@main_bp.route("/")
+@role_required(Role.VIEWER, Role.CONTRIBUTOR, Role.ADMIN)
+def index():
+    form = ScanForm()
+    stations = Station.query.filter_by(is_active=True).order_by(Station.sort_order, Station.name).all()
+    return render_template("index.html", form=form, stations=stations)
+
+
+@main_bp.route("/scan", methods=["POST"])
+@role_required(Role.VIEWER, Role.CONTRIBUTOR, Role.ADMIN)
+def scan():
+    form = ScanForm()
+    if form.validate_on_submit():
+        number = form.lieferscheinnummer.data.strip().upper()
+        delivery = Delivery.query.filter_by(lieferscheinnummer=number).first()
+        created = False
+        if not delivery:
+            delivery = Delivery(lieferscheinnummer=number)
+            db.session.add(delivery)
+            created = True
+        event = Event(
+            delivery=delivery,
+            actor_username=g.current_user.username,
+            type=EventType.SCAN,
+        )
+        db.session.add(event)
+        db.session.commit()
+        flash("Lieferschein erfasst" + (" (neu)" if created else ""), "success")
+        return redirect(url_for("main.delivery_detail", delivery_id=delivery.id))
+    flash("Scan fehlgeschlagen", "danger")
+    return redirect(url_for("main.index"))
+
+
+@main_bp.route("/deliveries")
+@role_required(Role.VIEWER, Role.CONTRIBUTOR, Role.ADMIN)
+def deliveries_list():
+    form = DeliverySearchForm(request.args, meta={"csrf": False})
+    stations = Station.query.order_by(Station.sort_order, Station.name).all()
+    form.station_id.choices = [(0, "Alle Stationen")] + [(s.id, s.name) for s in stations]
+
+    query = Delivery.query
+    if form.query.data:
+        like = f"%{form.query.data.strip()}%"
+        query = query.filter(Delivery.lieferscheinnummer.ilike(like))
+    if form.station_id.data and form.station_id.data != 0:
+        query = query.filter(Delivery.current_station_id == form.station_id.data)
+    if form.shipping_week.data:
+        query = query.filter(Delivery.shipping_week == form.shipping_week.data)
+    if form.priority.data is not None and form.priority.data != "":
+        query = query.filter(Delivery.priority == form.priority.data)
+
+    query = query.order_by(desc(Delivery.updated_at))
+
+    page = request.args.get("page", default=1, type=int)
+    pagination = query.paginate(page=page, per_page=25)
+
+    filters = request.args.to_dict()
+    filters.pop("page", None)
+
+    return render_template(
+        "deliveries_list.html",
+        deliveries=pagination.items,
+        pagination=pagination,
+        form=form,
+        pagination_range=pagination_range,
+        filters=filters,
+    )
+
+
+def get_delivery_or_404(delivery_id: int) -> Delivery:
+    delivery = Delivery.query.get_or_404(delivery_id)
+    return delivery
+
+
+@main_bp.route("/d/<int:delivery_id>")
+@role_required(Role.VIEWER, Role.CONTRIBUTOR, Role.ADMIN)
+def delivery_detail(delivery_id: int):
+    delivery = get_delivery_or_404(delivery_id)
+    station_form = DeliveryStationForm()
+    note_form = DeliveryNoteForm()
+    ship_form = DeliveryShipDateForm()
+    priority_form = DeliveryPriorityForm()
+
+    stations = Station.query.filter_by(is_active=True).order_by(Station.sort_order).all()
+    station_form.station_id.choices = [(s.id, s.name) for s in stations]
+    if delivery.current_station_id:
+        station_form.station_id.data = delivery.current_station_id
+    priority_form.priority.data = delivery.priority
+    if delivery.ship_date:
+        ship_form.ship_date.data = delivery.ship_date
+
+    events = Event.query.filter_by(delivery_id=delivery.id).order_by(Event.created_at.desc()).all()
+    eta = eta_for_station(delivery.current_station)
+    due_status = determine_due_status(delivery)
+
+    return render_template(
+        "delivery_detail.html",
+        delivery=delivery,
+        events=events,
+        station_form=station_form,
+        note_form=note_form,
+        ship_form=ship_form,
+        priority_form=priority_form,
+        eta=eta,
+        due_status=due_status,
+    )
+
+
+@main_bp.route("/d/<int:delivery_id>/station", methods=["POST"])
+@role_required(Role.ADMIN, Role.CONTRIBUTOR)
+def set_station(delivery_id: int):
+    delivery = get_delivery_or_404(delivery_id)
+    form = DeliveryStationForm()
+    stations = Station.query.filter_by(is_active=True).order_by(Station.sort_order).all()
+    form.station_id.choices = [(s.id, s.name) for s in stations]
+    if form.validate_on_submit():
+        station = Station.query.get(form.station_id.data)
+        if not station:
+            flash("Station nicht gefunden", "danger")
+        else:
+            delivery.current_station = station
+            event = Event(
+                delivery=delivery,
+                actor_username=g.current_user.username,
+                type=EventType.SET_STATION,
+                station=station,
+                new_value=station.name,
+            )
+            db.session.add_all([delivery, event])
+            db.session.commit()
+            flash("Station aktualisiert", "success")
+    else:
+        flash("Station konnte nicht gesetzt werden", "danger")
+    return redirect(url_for("main.delivery_detail", delivery_id=delivery.id))
+
+
+@main_bp.route("/d/<int:delivery_id>/note", methods=["POST"])
+@role_required(Role.ADMIN, Role.CONTRIBUTOR)
+def add_note(delivery_id: int):
+    delivery = get_delivery_or_404(delivery_id)
+    form = DeliveryNoteForm()
+    if form.validate_on_submit():
+        event = Event(
+            delivery=delivery,
+            actor_username=g.current_user.username,
+            type=EventType.NOTE,
+            note_text=form.note_text.data.strip(),
+        )
+        db.session.add(event)
+        db.session.commit()
+        flash("Notiz gespeichert", "success")
+    else:
+        flash("Notiz konnte nicht gespeichert werden", "danger")
+    return redirect(url_for("main.delivery_detail", delivery_id=delivery.id))
+
+
+@main_bp.route("/d/<int:delivery_id>/shipdate", methods=["POST"])
+@role_required(Role.ADMIN, Role.CONTRIBUTOR)
+def set_ship_date(delivery_id: int):
+    delivery = get_delivery_or_404(delivery_id)
+    form = DeliveryShipDateForm()
+    if form.validate_on_submit():
+        delivery.set_ship_date(form.ship_date.data)
+        event = Event(
+            delivery=delivery,
+            actor_username=g.current_user.username,
+            type=EventType.SET_SHIP_DATE,
+            new_value=form.ship_date.data.isoformat() if form.ship_date.data else "gelöscht",
+        )
+        db.session.add_all([delivery, event])
+        db.session.commit()
+        flash("Versanddatum gespeichert", "success")
+    else:
+        flash("Versanddatum ungültig", "danger")
+    return redirect(url_for("main.delivery_detail", delivery_id=delivery.id))
+
+
+@main_bp.route("/d/<int:delivery_id>/priority", methods=["POST"])
+@role_required(Role.ADMIN, Role.CONTRIBUTOR)
+def set_priority(delivery_id: int):
+    delivery = get_delivery_or_404(delivery_id)
+    form = DeliveryPriorityForm()
+    if form.validate_on_submit():
+        delivery.priority = form.priority.data
+        event = Event(
+            delivery=delivery,
+            actor_username=g.current_user.username,
+            type=EventType.SET_PRIORITY,
+            new_value=str(form.priority.data),
+        )
+        db.session.add_all([delivery, event])
+        db.session.commit()
+        flash("Priorität aktualisiert", "success")
+    else:
+        flash("Priorität ungültig", "danger")
+    return redirect(url_for("main.delivery_detail", delivery_id=delivery.id))
+
+
+@main_bp.route("/shipping")
+@role_required(Role.VIEWER, Role.CONTRIBUTOR, Role.ADMIN)
+def shipping_board():
+    scope = request.args.get("scope", "all")
+    today = date.today()
+    week = today.isocalendar().week
+
+    query = Delivery.query
+    if scope == "overdue":
+        query = query.filter(Delivery.ship_date != None, Delivery.ship_date < today)  # noqa: E711
+    elif scope == "today":
+        query = query.filter(Delivery.ship_date == today)
+    elif scope == "week":
+        query = query.filter(Delivery.shipping_week == week)
+    elif scope == "future":
+        query = query.filter(Delivery.ship_date != None, Delivery.ship_date > today)  # noqa: E711
+
+    deliveries = query.order_by(
+        desc(Delivery.priority),
+        nullslast(Delivery.ship_date.asc()),
+        desc(Delivery.updated_at),
+    ).all()
+
+    stations = Station.query.filter_by(is_active=True).order_by(Station.sort_order).all()
+
+    return render_template(
+        "shipping_board.html",
+        deliveries=deliveries,
+        scope=scope,
+        stations=stations,
+        today=today,
+    )
+
+
+@main_bp.route("/export.csv")
+@role_required(Role.VIEWER, Role.CONTRIBUTOR, Role.ADMIN)
+def export_csv():
+    scope = request.args.get("scope", "all")
+    today = date.today()
+    week = today.isocalendar().week
+
+    query = Delivery.query
+    if scope == "overdue":
+        query = query.filter(Delivery.ship_date != None, Delivery.ship_date < today)  # noqa: E711
+    elif scope == "today":
+        query = query.filter(Delivery.ship_date == today)
+    elif scope == "week":
+        query = query.filter(Delivery.shipping_week == week)
+
+    deliveries = query.order_by(desc(Delivery.priority), Delivery.ship_date, desc(Delivery.updated_at)).all()
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["lieferscheinnummer", "ship_date", "shipping_week", "priority", "station", "updated_at"])
+    for d in deliveries:
+        writer.writerow(
+            [
+                d.lieferscheinnummer,
+                d.ship_date.isoformat() if d.ship_date else "",
+                d.shipping_week or "",
+                d.priority,
+                d.current_station.name if d.current_station else "",
+                d.updated_at.isoformat() if d.updated_at else "",
+            ]
+        )
+    output.seek(0)
+    filename = f"export_{scope}.csv"
+    return Response(
+        output.getvalue(),
+        mimetype="text/csv",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+
+@admin_bp.route("/stations", methods=["GET", "POST"])
+@role_required(Role.ADMIN)
+def admin_stations():
+    form = StationForm()
+    delete_form = DeleteForm()
+    if form.submit.data and form.validate_on_submit():
+        if form.id.data:
+            station = Station.query.get_or_404(int(form.id.data))
+            station.name = form.name.data.strip()
+            station.info_text = form.info_text.data
+            station.default_duration_hours = form.default_duration_hours.data
+            station.sort_order = form.sort_order.data or 0
+            station.is_active = form.is_active.data == "1"
+            flash("Station aktualisiert", "success")
+        else:
+            station = Station(
+                name=form.name.data.strip(),
+                info_text=form.info_text.data,
+                default_duration_hours=form.default_duration_hours.data,
+                sort_order=form.sort_order.data or 0,
+                is_active=form.is_active.data == "1",
+            )
+            db.session.add(station)
+            flash("Station angelegt", "success")
+        db.session.commit()
+        return redirect(url_for("admin.admin_stations"))
+
+    if delete_form.delete.data and delete_form.validate_on_submit():
+        station = Station.query.get_or_404(int(delete_form.id.data))
+        db.session.delete(station)
+        db.session.commit()
+        flash("Station gelöscht", "info")
+        return redirect(url_for("admin.admin_stations"))
+
+    edit_id = request.args.get("edit", type=int)
+    if edit_id:
+        station = Station.query.get_or_404(edit_id)
+        form.id.data = str(station.id)
+        form.name.data = station.name
+        form.info_text.data = station.info_text
+        form.default_duration_hours.data = station.default_duration_hours
+        form.sort_order.data = station.sort_order
+        form.is_active.data = "1" if station.is_active else "0"
+
+    stations = Station.query.order_by(Station.sort_order, Station.name).all()
+    return render_template("admin_stations.html", stations=stations, form=form, delete_form=delete_form)
+
+
+@admin_bp.route("/users", methods=["GET", "POST"])
+@role_required(Role.ADMIN)
+def admin_users():
+    form = UserForm()
+    delete_form = DeleteForm()
+    if form.submit.data and form.validate_on_submit():
+        username = form.username.data.strip().lower()
+        if form.id.data:
+            user = User.query.get_or_404(int(form.id.data))
+            user.username = username
+            user.role = Role(form.role.data)
+            flash("Benutzer aktualisiert", "success")
+        else:
+            if User.query.filter_by(username=username).first():
+                flash("Benutzername bereits vergeben", "danger")
+            else:
+                user = User(username=username, role=Role(form.role.data))
+                db.session.add(user)
+                flash("Benutzer angelegt", "success")
+        db.session.commit()
+        return redirect(url_for("admin.admin_users"))
+
+    if delete_form.delete.data and delete_form.validate_on_submit():
+        user = User.query.get_or_404(int(delete_form.id.data))
+        if user.username == "admin":
+            flash("Admin kann nicht gelöscht werden", "warning")
+        else:
+            db.session.delete(user)
+            db.session.commit()
+            flash("Benutzer gelöscht", "info")
+        return redirect(url_for("admin.admin_users"))
+
+    edit_id = request.args.get("edit", type=int)
+    if edit_id:
+        user = User.query.get_or_404(edit_id)
+        form.id.data = str(user.id)
+        form.username.data = user.username
+        form.role.data = user.role.value
+
+    users = User.query.order_by(User.username).all()
+    return render_template("admin_users.html", users=users, form=form, delete_form=delete_form)
+
+
+@admin_bp.route("/devices", methods=["GET", "POST"])
+@role_required(Role.ADMIN)
+def admin_devices():
+    label_form = DeviceLabelForm()
+    revoke_form = RevokeDeviceForm()
+
+    if label_form.label.data and label_form.validate_on_submit():
+        device = Device.query.get_or_404(int(label_form.id.data))
+        device.device_label = label_form.device_label.data
+        db.session.commit()
+        flash("Gerätename aktualisiert", "success")
+        return redirect(url_for("admin.admin_devices"))
+
+    if revoke_form.revoke.data and revoke_form.validate_on_submit():
+        device = Device.query.get_or_404(int(revoke_form.id.data))
+        device.revoke()
+        db.session.commit()
+        flash("Gerät abgemeldet", "info")
+        return redirect(url_for("admin.admin_devices"))
+
+    devices = Device.query.order_by(Device.last_seen.desc()).all()
+    return render_template(
+        "admin_devices.html",
+        devices=devices,
+        label_form=label_form,
+        revoke_form=revoke_form,
+    )
+
+
+def register_cli(app: Flask) -> None:
+    @app.cli.command("init-db")
+    def init_db_command():
+        """Initialise database and seed demo data."""
+        os.makedirs(DB_PATH.parent, exist_ok=True)
+        init_db(app)
+        click = __import__("click")
+        click.echo("Database initialised and seeded.")
+
+
+app = create_app()
+
+if __name__ == "__main__":
+    os.makedirs(DB_PATH.parent, exist_ok=True)
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/tracker/auth.py
+++ b/tracker/auth.py
@@ -1,0 +1,128 @@
+"""Authentication helpers and blueprint for the tracker."""
+from __future__ import annotations
+
+import secrets
+import time
+from datetime import datetime
+from typing import Optional
+
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    g,
+    make_response,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+
+from .forms import LoginForm
+from .models import Device, User, db
+
+AUTH_COOKIE = "device_token"
+TOKEN_MAX_AGE = 60 * 60 * 24 * 365  # one year
+RATE_LIMIT_WINDOW = 60
+MAX_ATTEMPTS_PER_WINDOW = 20
+
+login_attempts: dict[str, list[float]] = {}
+
+auth_bp = Blueprint("auth", __name__)
+
+
+def record_attempt(ip: str) -> None:
+    now = time.time()
+    attempts = login_attempts.setdefault(ip, [])
+    attempts.append(now)
+    # prune old
+    login_attempts[ip] = [t for t in attempts if now - t <= RATE_LIMIT_WINDOW]
+
+
+def allowed_attempt(ip: str) -> bool:
+    record_attempt(ip)
+    return len(login_attempts.get(ip, [])) <= MAX_ATTEMPTS_PER_WINDOW
+
+
+def set_login_cookie(response, token: str) -> None:
+    secure = current_app.config.get("SESSION_COOKIE_SECURE", False)
+    response.set_cookie(
+        AUTH_COOKIE,
+        token,
+        max_age=TOKEN_MAX_AGE,
+        httponly=True,
+        samesite="Lax",
+        secure=secure,
+    )
+
+
+def clear_login_cookie(response) -> None:
+    response.delete_cookie(AUTH_COOKIE)
+
+
+@auth_bp.before_app_request
+def load_user_from_token() -> None:
+    token = request.cookies.get(AUTH_COOKIE)
+    g.current_user = None
+    g.current_device = None
+    if not token:
+        return
+    token_hash = Device.hash_token(token)
+    device = Device.query.filter_by(token_hash=token_hash, is_revoked=False).first()
+    if not device or not device.user:
+        return
+    device.last_seen = datetime.utcnow()
+    db.session.add(device)
+    db.session.commit()
+    g.current_user = device.user
+    g.current_device = device
+
+
+@auth_bp.route("/login", methods=["GET", "POST"])
+def login():
+    form = LoginForm()
+    if form.validate_on_submit():
+        client_ip = request.remote_addr or "unknown"
+        if not allowed_attempt(client_ip):
+            flash("Zu viele Login-Versuche. Bitte kurz warten.", "danger")
+            return render_template("login.html", form=form)
+
+        user = User.query.filter_by(username=form.username.data.strip().lower()).first()
+        if not user:
+            flash("Unbekannter Benutzer", "danger")
+            return render_template("login.html", form=form)
+
+        token = secrets.token_urlsafe(48)
+        device = Device(
+            user=user,
+            device_label=form.device_label.data or request.user_agent.string[:120],
+            token_hash=Device.hash_token(token),
+            last_seen=datetime.utcnow(),
+        )
+        db.session.add(device)
+        db.session.commit()
+        flash("Erfolgreich angemeldet", "success")
+        response = make_response(redirect(url_for("main.index")))
+        set_login_cookie(response, token)
+        return response
+    return render_template("login.html", form=form)
+
+
+@auth_bp.route("/logout", methods=["POST"])
+def logout():
+    response = make_response(redirect(url_for("auth.login")))
+    token = request.cookies.get(AUTH_COOKIE)
+    if token:
+        token_hash = Device.hash_token(token)
+        device = Device.query.filter_by(token_hash=token_hash).first()
+        if device:
+            device.revoke()
+            db.session.commit()
+    clear_login_cookie(response)
+    flash("Abgemeldet", "info")
+    return response
+
+
+@auth_bp.app_context_processor
+def inject_user() -> dict[str, Optional[User]]:
+    return {"current_user": getattr(g, "current_user", None)}

--- a/tracker/forms.py
+++ b/tracker/forms.py
@@ -1,0 +1,96 @@
+"""Forms used throughout the tracker application."""
+from __future__ import annotations
+
+from flask_wtf import FlaskForm
+from wtforms import DateField, HiddenField, IntegerField, SelectField, StringField, SubmitField, TextAreaField
+from wtforms.validators import DataRequired, Length, Optional, Regexp
+
+from .models import Role
+
+USERNAME_RE = r"^[A-Za-z0-9_.-]+$"
+LIEFERSCHEIN_RE = r"^[A-Za-z0-9_-]{3,120}$"
+
+
+class LoginForm(FlaskForm):
+    username = StringField("Benutzername", validators=[DataRequired(), Length(max=80), Regexp(USERNAME_RE)])
+    device_label = StringField("Gerätename", validators=[Optional(), Length(max=120)])
+    submit = SubmitField("Anmelden")
+
+
+class ScanForm(FlaskForm):
+    lieferscheinnummer = StringField(
+        "Lieferscheinnummer",
+        validators=[DataRequired(), Length(min=3, max=120), Regexp(LIEFERSCHEIN_RE)],
+        render_kw={"autofocus": True, "data-scan-input": "true"},
+    )
+    submit = SubmitField("Scannen")
+
+
+class DeliveryStationForm(FlaskForm):
+    station_id = SelectField("Station", coerce=int, validators=[DataRequired()])
+    submit = SubmitField("Station setzen")
+
+
+class DeliveryNoteForm(FlaskForm):
+    note_text = TextAreaField("Notiz", validators=[DataRequired(), Length(max=2000)])
+    submit = SubmitField("Notiz speichern")
+
+
+class DeliveryShipDateForm(FlaskForm):
+    ship_date = DateField("Versanddatum", validators=[Optional()])
+    submit = SubmitField("Speichern")
+
+
+class DeliveryPriorityForm(FlaskForm):
+    priority = IntegerField("Priorität", validators=[DataRequired()])
+    submit = SubmitField("Priorität setzen")
+
+
+class DeliverySearchForm(FlaskForm):
+    query = StringField("Suche", validators=[Optional(), Length(max=120)])
+    station_id = SelectField("Station", coerce=int, validators=[Optional()], default=0)
+    shipping_week = IntegerField("Lieferwoche", validators=[Optional()])
+    priority = IntegerField("Priorität", validators=[Optional()])
+    submit = SubmitField("Filtern")
+
+
+class StationForm(FlaskForm):
+    id = HiddenField()
+    name = StringField("Name", validators=[DataRequired(), Length(max=120)])
+    info_text = TextAreaField("Info", validators=[Optional()])
+    default_duration_hours = IntegerField("Standarddauer (h)", validators=[Optional()])
+    sort_order = IntegerField("Sortierung", validators=[Optional()])
+    is_active = SelectField(
+        "Aktiv",
+        choices=[("1", "Ja"), ("0", "Nein")],
+        default="1",
+        validators=[DataRequired()],
+    )
+    submit = SubmitField("Speichern")
+
+
+class UserForm(FlaskForm):
+    id = HiddenField()
+    username = StringField("Benutzername", validators=[DataRequired(), Length(max=80), Regexp(USERNAME_RE)])
+    role = SelectField(
+        "Rolle",
+        choices=[(Role.ADMIN.value, "Admin"), (Role.CONTRIBUTOR.value, "Bearbeiter"), (Role.VIEWER.value, "Viewer")],
+        validators=[DataRequired()],
+    )
+    submit = SubmitField("Speichern")
+
+
+class DeviceLabelForm(FlaskForm):
+    id = HiddenField()
+    device_label = StringField("Gerätename", validators=[Optional(), Length(max=120)])
+    label = SubmitField("Aktualisieren")
+
+
+class RevokeDeviceForm(FlaskForm):
+    id = HiddenField(validators=[DataRequired()])
+    revoke = SubmitField("Revoke")
+
+
+class DeleteForm(FlaskForm):
+    id = HiddenField(validators=[DataRequired()])
+    delete = SubmitField("Löschen")

--- a/tracker/models.py
+++ b/tracker/models.py
@@ -1,0 +1,162 @@
+"""Database models for the delivery tracker."""
+from __future__ import annotations
+
+import enum
+import hashlib
+from datetime import datetime, date
+from typing import Optional
+
+from flask import current_app
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import Index
+
+
+db = SQLAlchemy()
+
+
+class Role(enum.StrEnum):
+    """Roles available for users."""
+
+    ADMIN = "admin"
+    CONTRIBUTOR = "contrib"
+    VIEWER = "viewer"
+
+
+class EventType(enum.StrEnum):
+    """Event types for delivery timeline."""
+
+    SCAN = "scan"
+    SET_STATION = "set_station"
+    NOTE = "note"
+    SET_SHIP_DATE = "set_ship_date"
+    SET_PRIORITY = "set_priority"
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    role = db.Column(db.Enum(Role), nullable=False, default=Role.VIEWER)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    devices = db.relationship("Device", backref="user", lazy=True)
+    events = db.relationship("Event", backref="delivery_actor", lazy=True)
+
+    def is_admin(self) -> bool:
+        return self.role == Role.ADMIN
+
+    def can_contribute(self) -> bool:
+        return self.role in {Role.ADMIN, Role.CONTRIBUTOR}
+
+
+class Station(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), unique=True, nullable=False)
+    info_text = db.Column(db.Text, nullable=True)
+    default_duration_hours = db.Column(db.Integer, nullable=True)
+    sort_order = db.Column(db.Integer, default=0)
+    is_active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    deliveries = db.relationship("Delivery", backref="current_station", lazy=True)
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        return f"<Station {self.name}>"
+
+
+class Delivery(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    lieferscheinnummer = db.Column(db.String(120), unique=True, nullable=False, index=True)
+    current_station_id = db.Column(db.Integer, db.ForeignKey("station.id"), nullable=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+    ship_date = db.Column(db.Date, nullable=True)
+    shipping_week = db.Column(db.Integer, nullable=True)
+    priority = db.Column(db.Integer, nullable=False, default=0)
+
+    events = db.relationship("Event", backref="delivery", lazy=True, order_by="Event.created_at.desc()")
+
+    __table_args__ = (
+        Index("ix_delivery_shipping_week", "shipping_week"),
+        Index("ix_delivery_ship_date", "ship_date"),
+        Index("ix_delivery_priority", "priority"),
+        Index("ix_delivery_updated_at", "updated_at"),
+    )
+
+    def set_ship_date(self, ship_date_value: Optional[date]) -> None:
+        """Set ship date and calculate ISO week."""
+        self.ship_date = ship_date_value
+        if ship_date_value is None:
+            self.shipping_week = None
+        else:
+            self.shipping_week = ship_date_value.isocalendar().week
+
+
+class Event(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    delivery_id = db.Column(db.Integer, db.ForeignKey("delivery.id"), nullable=False)
+    actor_username = db.Column(db.String(80), nullable=False)
+    type = db.Column(db.Enum(EventType), nullable=False)
+    station_id = db.Column(db.Integer, db.ForeignKey("station.id"), nullable=True)
+    note_text = db.Column(db.Text, nullable=True)
+    new_value = db.Column(db.String(120), nullable=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+
+    station = db.relationship("Station")
+
+
+class Device(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    device_label = db.Column(db.String(120), nullable=True)
+    token_hash = db.Column(db.String(128), nullable=False, index=True)
+    last_seen = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    is_revoked = db.Column(db.Boolean, default=False, nullable=False)
+
+    @staticmethod
+    def hash_token(token: str) -> str:
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    def revoke(self) -> None:
+        self.is_revoked = True
+        db.session.add(self)
+
+
+def init_db(app) -> None:
+    """Initialise the database, seed basic data and create admin user."""
+    with app.app_context():
+        db.create_all()
+
+        if not User.query.filter_by(username="admin").first():
+            admin_user = User(username="admin", role=Role.ADMIN)
+            contrib_user = User(username="halle", role=Role.CONTRIBUTOR)
+            viewer_user = User(username="buero", role=Role.VIEWER)
+            db.session.add_all([admin_user, contrib_user, viewer_user])
+            current_app.logger.info("Seeded default users: admin, halle, buero")
+
+        if Station.query.count() == 0:
+            stations = [
+                Station(name="Eingang", sort_order=10, is_active=True),
+                Station(name="Halle A", sort_order=20, is_active=True),
+                Station(name="Halle B", sort_order=30, is_active=True),
+                Station(name="Pulverbeschichtung", sort_order=40, is_active=True),
+                Station(name="Versand", sort_order=50, is_active=True),
+                Station(name="Versand abgeschlossen", sort_order=60, is_active=True),
+            ]
+            db.session.add_all(stations)
+            current_app.logger.info("Seeded example stations")
+
+        db.session.commit()
+
+
+def touch_updated_at(mapper, connection, target) -> None:
+    connection.execute(
+        Delivery.__table__.update()
+        .where(Delivery.id == target.delivery_id)
+        .values(updated_at=datetime.utcnow())
+    )
+
+
+# ensure updated_at touches on event creation
+from sqlalchemy import event as sa_event  # noqa: E402
+
+sa_event.listen(Event, "after_insert", touch_updated_at)

--- a/tracker/requirements.txt
+++ b/tracker/requirements.txt
@@ -1,0 +1,10 @@
+Flask==2.3.3
+Flask-WTF==1.1.1
+SQLAlchemy==2.0.21
+Flask-SQLAlchemy==3.0.5
+python-dotenv==1.0.0
+bleach==6.0.0
+WTForms==3.0.1
+itsdangerous==2.1.2
+click==8.1.7
+Markdown==3.4.4

--- a/tracker/static/app.css
+++ b/tracker/static/app.css
@@ -1,0 +1,124 @@
+:root {
+  --tracker-yellow: #f2c200;
+  --tracker-bg: #0f1115;
+  --tracker-surface: #161922;
+  --tracker-text: #f8f9fa;
+}
+
+body {
+  background: radial-gradient(circle at top left, rgba(242, 194, 0, 0.1), transparent 45%), var(--tracker-bg);
+  color: var(--tracker-text);
+  font-family: "Barlow", "Segoe UI", sans-serif;
+  letter-spacing: 0.03em;
+}
+
+h1, h2, h3, .navbar-brand {
+  letter-spacing: 0.08em;
+}
+
+.text-monospace {
+  font-family: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 1.2rem;
+}
+
+.navbar {
+  background: rgba(22, 25, 34, 0.95);
+  backdrop-filter: blur(6px);
+}
+
+.card {
+  background-color: var(--tracker-surface);
+  border-radius: 1rem;
+}
+
+.card.bg-gradient-dark {
+  background: linear-gradient(135deg, rgba(242, 194, 0, 0.12), rgba(15, 17, 21, 0.95));
+}
+
+.btn-warning,
+.btn-outline-warning:hover,
+.btn-outline-warning:focus {
+  color: #1a1d2a;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.btn-warning {
+  background-color: var(--tracker-yellow);
+  border-color: var(--tracker-yellow);
+}
+
+.btn-outline-warning {
+  border-width: 2px;
+}
+
+.badge {
+  border-radius: 999px;
+  padding: 0.5rem 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.table > :not(caption) > * > * {
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+.flash-container {
+  position: sticky;
+  top: 1rem;
+  z-index: 1000;
+}
+
+.scan-form input {
+  font-size: 1.8rem;
+  padding: 1rem;
+}
+
+.station-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.station-card {
+  border: 1px solid rgba(242, 194, 0, 0.2);
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: rgba(18, 18, 24, 0.85);
+  min-height: 150px;
+}
+
+.station-info p {
+  margin-bottom: 0.5rem;
+}
+
+.alert {
+  border-left: 4px solid var(--tracker-yellow);
+}
+
+form .form-control,
+form .form-select {
+  background-color: rgba(15, 17, 21, 0.9);
+  border: 1px solid rgba(242, 194, 0, 0.3);
+  color: var(--tracker-text);
+}
+
+form .form-control:focus,
+form .form-select:focus {
+  border-color: var(--tracker-yellow);
+  box-shadow: 0 0 0 0.25rem rgba(242, 194, 0, 0.15);
+}
+
+.kiosk-active body {
+  cursor: none;
+}
+
+@media (max-width: 576px) {
+  .navbar-brand {
+    font-size: 1rem;
+  }
+
+  .scan-form input {
+    font-size: 1.4rem;
+  }
+}

--- a/tracker/static/app.js
+++ b/tracker/static/app.js
@@ -1,0 +1,61 @@
+(function () {
+  const scanInput = document.querySelector('[data-scan-input]');
+  if (scanInput) {
+    const focusScan = () => {
+      setTimeout(() => {
+        scanInput.focus();
+        scanInput.select();
+      }, 150);
+    };
+    focusScan();
+    document.querySelectorAll('[data-reset-scan]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        scanInput.value = '';
+        focusScan();
+      });
+    });
+    window.addEventListener('pageshow', focusScan);
+  }
+
+  const kioskBtn = document.getElementById('kiosk-btn');
+  if (kioskBtn && document.documentElement.requestFullscreen) {
+    kioskBtn.addEventListener('click', () => {
+      if (!document.fullscreenElement) {
+        document.documentElement.requestFullscreen().catch(() => {});
+      } else {
+        document.exitFullscreen().catch(() => {});
+      }
+    });
+  }
+
+  let audioCtx;
+  function beep(frequency, duration) {
+    try {
+      audioCtx = audioCtx || new (window.AudioContext || window.webkitAudioContext)();
+    } catch (err) {
+      return;
+    }
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    osc.type = 'square';
+    osc.frequency.value = frequency;
+    gain.gain.value = 0.08;
+    osc.connect(gain);
+    gain.connect(audioCtx.destination);
+    osc.start();
+    setTimeout(() => {
+      osc.stop();
+    }, duration);
+  }
+
+  document.querySelectorAll('[data-flash-category]').forEach((alert) => {
+    const category = alert.getAttribute('data-flash-category');
+    if (category === 'success') {
+      beep(880, 180);
+    } else if (category === 'danger' || category === 'error') {
+      beep(220, 260);
+    } else if (category === 'warning') {
+      beep(440, 200);
+    }
+  });
+})();

--- a/tracker/templates/admin_devices.html
+++ b/tracker/templates/admin_devices.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% block title %}Geräte | Liefer-Tracker{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 text-uppercase text-warning">Geräteverwaltung</h1>
+  <span class="text-secondary small">Aktive Tokens überwachen und bei Bedarf sperren.</span>
+</div>
+
+<div class="card bg-dark border border-secondary shadow">
+  <div class="table-responsive">
+    <table class="table table-dark table-striped align-middle mb-0">
+      <thead class="text-secondary small text-uppercase">
+        <tr>
+          <th>ID</th>
+          <th>User</th>
+          <th>Gerätename</th>
+          <th>Letzte Nutzung</th>
+          <th>Status</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for device in devices %}
+        <tr>
+          <td>{{ device.id }}</td>
+          <td>{{ device.user.username }}</td>
+          <td>
+            <form method="post" class="d-flex align-items-center gap-2">
+              {{ label_form.csrf_token }}
+              <input type="hidden" name="id" value="{{ device.id }}">
+              <input type="text" name="device_label" value="{{ device.device_label or '' }}" class="form-control form-control-sm bg-dark text-light border-secondary">
+              <button type="submit" name="label" value="1" class="btn btn-sm btn-outline-warning"><i class="bi bi-save"></i></button>
+            </form>
+          </td>
+          <td><span class="text-secondary small" title="{{ device.last_seen.isoformat() if device.last_seen else '' }}">{{ device.last_seen.strftime('%d.%m.%Y %H:%M') if device.last_seen else '' }}</span></td>
+          <td>{% if device.is_revoked %}<span class="badge bg-danger">Revoked</span>{% else %}<span class="badge bg-success">Aktiv</span>{% endif %}</td>
+          <td class="text-end">
+            <form method="post" class="d-inline" onsubmit="return confirm('Gerät abmelden?');">
+              {{ revoke_form.csrf_token }}
+              <input type="hidden" name="id" value="{{ device.id }}">
+              <button type="submit" name="revoke" value="1" class="btn btn-sm btn-outline-danger" {% if device.is_revoked %}disabled{% endif %}><i class="bi bi-x-octagon"></i></button>
+            </form>
+          </td>
+        </tr>
+        {% else %}
+        <tr>
+          <td colspan="6" class="text-center text-secondary py-5">Keine Geräte registriert.</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/tracker/templates/admin_stations.html
+++ b/tracker/templates/admin_stations.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+{% block title %}Stationen | Liefer-Tracker{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 text-uppercase text-warning">Stationen verwalten</h1>
+  <a class="btn btn-outline-warning" href="{{ url_for('admin.admin_stations') }}"><i class="bi bi-plus-circle"></i> Neu</a>
+</div>
+
+<div class="row g-4">
+  <div class="col-lg-5">
+    <div class="card bg-dark border border-secondary shadow">
+      <div class="card-header text-uppercase text-warning">Station bearbeiten/anlegen</div>
+      <div class="card-body">
+        <form method="post">
+          {{ form.hidden_tag() }}
+          {{ form.id }}
+          <div class="mb-3">
+            {{ form.name.label(class_='form-label text-uppercase small text-secondary') }}
+            {{ form.name(class_='form-control form-control-lg') }}
+          </div>
+          <div class="mb-3">
+            {{ form.info_text.label(class_='form-label text-uppercase small text-secondary') }}
+            {{ form.info_text(class_='form-control', rows=4) }}
+          </div>
+          <div class="row g-3">
+            <div class="col-md-4">
+              {{ form.default_duration_hours.label(class_='form-label text-uppercase small text-secondary') }}
+              {{ form.default_duration_hours(class_='form-control') }}
+            </div>
+            <div class="col-md-4">
+              {{ form.sort_order.label(class_='form-label text-uppercase small text-secondary') }}
+              {{ form.sort_order(class_='form-control') }}
+            </div>
+            <div class="col-md-4">
+              {{ form.is_active.label(class_='form-label text-uppercase small text-secondary') }}
+              {{ form.is_active(class_='form-select') }}
+            </div>
+          </div>
+          <button type="submit" name="submit" value="1" class="btn btn-warning mt-4 w-100"><i class="bi bi-save"></i> Speichern</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-7">
+    <div class="card bg-dark border border-secondary shadow">
+      <div class="card-header text-uppercase text-warning">Bestehende Stationen</div>
+      <div class="table-responsive">
+        <table class="table table-dark table-striped align-middle mb-0">
+          <thead class="text-secondary small text-uppercase">
+            <tr>
+              <th>Name</th>
+              <th>Standarddauer</th>
+              <th>Sortierung</th>
+              <th>Aktiv</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for station in stations %}
+            <tr>
+              <td>{{ station.name }}</td>
+              <td>{{ station.default_duration_hours or '-' }}</td>
+              <td>{{ station.sort_order }}</td>
+              <td>{% if station.is_active %}<span class="badge bg-warning text-dark">Aktiv</span>{% else %}<span class="badge bg-secondary">Inaktiv</span>{% endif %}</td>
+              <td class="text-end">
+                <a class="btn btn-sm btn-outline-warning" href="{{ url_for('admin.admin_stations', edit=station.id) }}"><i class="bi bi-pencil"></i></a>
+                <form method="post" class="d-inline-block" onsubmit="return confirm('Station wirklich löschen?');">
+                  {{ delete_form.csrf_token }}
+                  <input type="hidden" name="id" value="{{ station.id }}">
+                  <button type="submit" name="delete" value="1" class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+                </form>
+              </td>
+            </tr>
+            {% else %}
+            <tr>
+              <td colspan="5" class="text-center text-secondary py-5">Keine Stationen vorhanden.</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/tracker/templates/admin_users.html
+++ b/tracker/templates/admin_users.html
@@ -1,0 +1,69 @@
+{% extends "base.html" %}
+{% block title %}Nutzer | Liefer-Tracker{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 text-uppercase text-warning">Benutzerverwaltung</h1>
+  <a class="btn btn-outline-warning" href="{{ url_for('admin.admin_users') }}"><i class="bi bi-plus-circle"></i> Neu</a>
+</div>
+
+<div class="row g-4">
+  <div class="col-lg-5">
+    <div class="card bg-dark border border-secondary shadow">
+      <div class="card-header text-uppercase text-warning">Benutzer bearbeiten/anlegen</div>
+      <div class="card-body">
+        <form method="post">
+          {{ form.hidden_tag() }}
+          {{ form.id }}
+          <div class="mb-3">
+            {{ form.username.label(class_='form-label text-uppercase small text-secondary') }}
+            {{ form.username(class_='form-control form-control-lg') }}
+          </div>
+          <div class="mb-3">
+            {{ form.role.label(class_='form-label text-uppercase small text-secondary') }}
+            {{ form.role(class_='form-select form-select-lg') }}
+          </div>
+          <button type="submit" name="submit" value="1" class="btn btn-warning w-100"><i class="bi bi-save"></i> Speichern</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-7">
+    <div class="card bg-dark border border-secondary shadow">
+      <div class="card-header text-uppercase text-warning">Bestehende Benutzer</div>
+      <div class="table-responsive">
+        <table class="table table-dark table-striped align-middle mb-0">
+          <thead class="text-secondary small text-uppercase">
+            <tr>
+              <th>Benutzername</th>
+              <th>Rolle</th>
+              <th>Erstellt</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for user in users %}
+            <tr>
+              <td>{{ user.username }}</td>
+              <td>{{ user.role.value }}</td>
+              <td>{{ user.created_at.strftime('%d.%m.%Y %H:%M') if user.created_at else '' }}</td>
+              <td class="text-end">
+                <a class="btn btn-sm btn-outline-warning" href="{{ url_for('admin.admin_users', edit=user.id) }}"><i class="bi bi-pencil"></i></a>
+                <form method="post" class="d-inline-block" onsubmit="return confirm('Benutzer wirklich löschen?');">
+                  {{ delete_form.csrf_token }}
+                  <input type="hidden" name="id" value="{{ user.id }}">
+                  <button type="submit" name="delete" value="1" class="btn btn-sm btn-outline-danger" {% if user.username == 'admin' %}disabled{% endif %}><i class="bi bi-trash"></i></button>
+                </form>
+              </td>
+            </tr>
+            {% else %}
+            <tr>
+              <td colspan="4" class="text-center text-secondary py-5">Keine Benutzer vorhanden.</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/tracker/templates/base.html
+++ b/tracker/templates/base.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="de" data-bs-theme="dark">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}Liefer-Tracker{% endblock %}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='app.css') }}">
+    {% block head_extra %}{% endblock %}
+  </head>
+  <body class="bg-dark text-light">
+    <nav class="navbar navbar-expand-lg navbar-dark border-bottom border-warning-subtle">
+      <div class="container-fluid">
+        <a class="navbar-brand fw-semibold text-uppercase" href="{{ url_for('main.index') }}">
+          <i class="bi bi-box-seam"></i> Liefer-Tracker
+        </a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="mainNav">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('main.index') }}">Scan</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('main.deliveries_list') }}">Lieferungen</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('main.shipping_board') }}">Versand</a></li>
+            {% if current_user and current_user.is_admin() %}
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown" role="button" aria-expanded="false">Admin</a>
+              <ul class="dropdown-menu dropdown-menu-dark">
+                <li><a class="dropdown-item" href="{{ url_for('admin.admin_stations') }}">Stationen</a></li>
+                <li><a class="dropdown-item" href="{{ url_for('admin.admin_users') }}">Nutzer</a></li>
+                <li><a class="dropdown-item" href="{{ url_for('admin.admin_devices') }}">Geräte</a></li>
+              </ul>
+            </li>
+            {% endif %}
+          </ul>
+          <div class="d-flex align-items-center gap-3">
+            <button class="btn btn-outline-warning btn-sm" id="kiosk-btn" type="button"><i class="bi bi-fullscreen"></i> Kiosk</button>
+            {% if current_user %}
+            <span class="navbar-text text-warning small text-uppercase">{{ current_user.username }}</span>
+            <form method="post" action="{{ url_for('auth.logout') }}" class="ms-2">
+              {{ csrf_token() }}
+              <button class="btn btn-sm btn-warning" type="submit"><i class="bi bi-box-arrow-right"></i></button>
+            </form>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <main class="container-fluid py-4">
+      {% with messages = get_flashed_messages(with_categories=True) %}
+        {% if messages %}
+        <div class="flash-container">
+          {% for category, message in messages %}
+            <div class="alert alert-{{ category }} shadow-sm" role="alert" data-flash-category="{{ category }}">{{ message }}</div>
+          {% endfor %}
+        </div>
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
+    <script src="{{ url_for('static', filename='app.js') }}"></script>
+    {% block body_extra %}{% endblock %}
+  </body>
+</html>

--- a/tracker/templates/deliveries_list.html
+++ b/tracker/templates/deliveries_list.html
@@ -1,0 +1,102 @@
+{% extends "base.html" %}
+{% block title %}Lieferungen | Liefer-Tracker{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <div>
+    <h1 class="h3 text-uppercase text-warning">Lieferungen</h1>
+    <p class="text-secondary small">Filter nach Station, Kalenderwoche oder Priorität. Ergebnisse sind nach Aktualisierung sortiert.</p>
+  </div>
+  <a class="btn btn-outline-warning" href="{{ url_for('main.shipping_board') }}"><i class="bi bi-truck"></i> Versandübersicht</a>
+</div>
+
+<div class="card bg-dark border border-secondary shadow mb-4">
+  <div class="card-body">
+    <form method="get" class="row g-3 align-items-end">
+      <div class="col-sm-6 col-lg-3">
+        {{ form.query.label(class_='form-label text-uppercase small text-secondary') }}
+        {{ form.query(class_='form-control form-control-lg text-monospace', placeholder='Suche...') }}
+      </div>
+      <div class="col-sm-6 col-lg-3">
+        {{ form.station_id.label(class_='form-label text-uppercase small text-secondary') }}
+        {{ form.station_id(class_='form-select form-select-lg') }}
+      </div>
+      <div class="col-sm-6 col-lg-2">
+        {{ form.shipping_week.label(class_='form-label text-uppercase small text-secondary') }}
+        {{ form.shipping_week(class_='form-control form-control-lg', placeholder='KW') }}
+      </div>
+      <div class="col-sm-6 col-lg-2">
+        {{ form.priority.label(class_='form-label text-uppercase small text-secondary') }}
+        {{ form.priority(class_='form-control form-control-lg', placeholder='0-2') }}
+      </div>
+      <div class="col-sm-6 col-lg-2">
+        <button type="submit" class="btn btn-warning btn-lg w-100"><i class="bi bi-funnel"></i> Filtern</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div class="card bg-dark border border-secondary shadow">
+  <div class="table-responsive">
+    <table class="table table-dark table-hover align-middle mb-0">
+      <thead class="text-secondary text-uppercase small">
+        <tr>
+          <th>#</th>
+          <th>Station</th>
+          <th>Versand</th>
+          <th>Priorität</th>
+          <th>Aktualisiert</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for delivery in deliveries %}
+        {% set due_status = determine_due_status(delivery) %}
+        {% set priority_label, priority_class = priority_badge(delivery.priority) %}
+        <tr>
+          <td class="text-monospace fw-semibold">{{ delivery.lieferscheinnummer }}</td>
+          <td>
+            {% if delivery.current_station %}
+            <span class="badge bg-warning text-dark">{{ delivery.current_station.name }}</span>
+            {% else %}
+            <span class="text-secondary">(keine)</span>
+            {% endif %}
+          </td>
+          <td>
+            {% if delivery.ship_date %}
+            <span class="badge {{ due_badge_class(due_status) }}">{{ delivery.ship_date.strftime('%d.%m.%Y') }}</span>
+            {% else %}
+            <span class="text-secondary">offen</span>
+            {% endif %}
+          </td>
+          <td><span class="badge {{ priority_class }}">{{ priority_label }}</span></td>
+          <td><span class="text-secondary small" title="{{ delivery.updated_at.isoformat() if delivery.updated_at else '' }}">{{ delivery.updated_at.strftime('%d.%m.%Y %H:%M') if delivery.updated_at else '' }}</span></td>
+          <td class="text-end"><a class="btn btn-sm btn-outline-warning" href="{{ url_for('main.delivery_detail', delivery_id=delivery.id) }}"><i class="bi bi-box-arrow-in-right"></i></a></td>
+        </tr>
+        {% else %}
+        <tr>
+          <td colspan="6" class="text-center text-secondary py-5">Keine Einträge gefunden.</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+{% if pagination.pages > 1 %}
+<nav class="mt-4" aria-label="Pagination">
+  <ul class="pagination pagination-lg justify-content-center">
+    <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('main.deliveries_list', page=pagination.prev_num, **filters) }}">&laquo;</a>
+    </li>
+    {% for p in pagination_range(pagination.page, pagination.pages) %}
+    <li class="page-item {% if p == pagination.page %}active{% endif %}">
+      <a class="page-link" href="{{ url_for('main.deliveries_list', page=p, **filters) }}">{{ p }}</a>
+    </li>
+    {% endfor %}
+    <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
+      <a class="page-link" href="{{ url_for('main.deliveries_list', page=pagination.next_num, **filters) }}">&raquo;</a>
+    </li>
+  </ul>
+</nav>
+{% endif %}
+{% endblock %}

--- a/tracker/templates/delivery_detail.html
+++ b/tracker/templates/delivery_detail.html
@@ -1,0 +1,116 @@
+{% extends "base.html" %}
+{% block title %}{{ delivery.lieferscheinnummer }} | Liefer-Tracker{% endblock %}
+{% block content %}
+<div class="d-flex flex-column flex-lg-row gap-4">
+  <div class="flex-fill">
+    <div class="card bg-dark border border-warning shadow-lg">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-start mb-3">
+          <div>
+            <h1 class="display-6 text-warning text-monospace">{{ delivery.lieferscheinnummer }}</h1>
+            {% if delivery.current_station %}
+            <span class="badge bg-warning text-dark text-uppercase">{{ delivery.current_station.name }}</span>
+            {% else %}
+            <span class="badge bg-secondary text-uppercase">Keine Station</span>
+            {% endif %}
+            {% if due_status %}
+            <span class="badge {{ due_badge_class(due_status) }} text-uppercase ms-2">{{ {'overdue':'Überfällig','today':'Heute','week':'Diese Woche'}.get(due_status,'') }}</span>
+            {% endif %}
+          </div>
+          <div class="text-end text-secondary small">
+            <div>Erstellt: {{ delivery.created_at.strftime('%d.%m.%Y %H:%M') if delivery.created_at else '' }}</div>
+            <div>Aktualisiert: {{ delivery.updated_at.strftime('%d.%m.%Y %H:%M') if delivery.updated_at else '' }}</div>
+          </div>
+        </div>
+        {% if delivery.current_station and delivery.current_station.info_text %}
+        <div class="alert alert-secondary text-dark">
+          {{ markdown_safe(delivery.current_station.info_text) | safe }}
+        </div>
+        {% endif %}
+        <dl class="row text-secondary small">
+          <dt class="col-sm-3 text-uppercase">Versanddatum</dt>
+          <dd class="col-sm-9">
+            {% if delivery.ship_date %}
+            {{ delivery.ship_date.strftime('%d.%m.%Y') }} (KW {{ delivery.shipping_week }})
+            {% else %}
+            <span class="text-muted">offen</span>
+            {% endif %}
+          </dd>
+          <dt class="col-sm-3 text-uppercase">Priorität</dt>
+          {% set priority_label, priority_class = priority_badge(delivery.priority) %}
+          <dd class="col-sm-9"><span class="badge {{ priority_class }}">{{ priority_label }}</span></dd>
+          {% if eta %}
+          <dt class="col-sm-3 text-uppercase">ETA</dt>
+          <dd class="col-sm-9">{{ eta.strftime('%d.%m.%Y %H:%M') }} UTC</dd>
+          {% endif %}
+        </dl>
+      </div>
+    </div>
+
+    {% if events %}
+    <div class="card bg-dark border border-secondary shadow mt-4">
+      <div class="card-header text-uppercase text-warning">Timeline</div>
+      <div class="list-group list-group-flush">
+        {% for event in events %}
+        <div class="list-group-item bg-dark text-light border-secondary">
+          <div class="d-flex justify-content-between">
+            <div>
+              <span class="badge bg-secondary text-uppercase">{{ event.type }}</span>
+              <span class="text-warning">{{ event.actor_username }}</span>
+            </div>
+            <span class="text-secondary small" title="{{ event.created_at.isoformat() }}">{{ event.created_at.strftime('%d.%m.%Y %H:%M') }}</span>
+          </div>
+          {% if event.station %}
+          <div class="mt-2 text-muted small"><i class="bi bi-diagram-3"></i> {{ event.station.name }}</div>
+          {% endif %}
+          {% if event.note_text %}
+          <div class="mt-2 text-muted">{{ event.note_text }}</div>
+          {% endif %}
+          {% if event.new_value and not event.note_text %}
+          <div class="mt-2 text-muted small"><i class="bi bi-arrow-right"></i> {{ event.new_value }}</div>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+  </div>
+
+  {% if current_user and current_user.can_contribute() %}
+  <div class="flex-shrink-0" style="min-width: 320px;">
+    <div class="card bg-dark border border-secondary shadow">
+      <div class="card-header text-uppercase text-warning">Aktionen</div>
+      <div class="card-body d-grid gap-4">
+        <form method="post" action="{{ url_for('main.set_station', delivery_id=delivery.id) }}">
+          {{ station_form.hidden_tag() }}
+          <label class="form-label text-uppercase small text-secondary">Station</label>
+          {{ station_form.station_id(class_='form-select form-select-lg') }}
+          <button class="btn btn-warning w-100 mt-2" type="submit"><i class="bi bi-diagram-3"></i> Station setzen</button>
+        </form>
+
+        <form method="post" action="{{ url_for('main.set_priority', delivery_id=delivery.id) }}">
+          {{ priority_form.hidden_tag() }}
+          <label class="form-label text-uppercase small text-secondary">Priorität (0-2)</label>
+          {{ priority_form.priority(class_='form-control form-control-lg') }}
+          <button class="btn btn-warning w-100 mt-2" type="submit"><i class="bi bi-exclamation-triangle"></i> Priorität setzen</button>
+        </form>
+
+        <form method="post" action="{{ url_for('main.set_ship_date', delivery_id=delivery.id) }}">
+          {{ ship_form.hidden_tag() }}
+          <label class="form-label text-uppercase small text-secondary">Versanddatum</label>
+          {{ ship_form.ship_date(class_='form-control form-control-lg') }}
+          <button class="btn btn-warning w-100 mt-2" type="submit"><i class="bi bi-calendar-check"></i> Versanddatum speichern</button>
+        </form>
+
+        <form method="post" action="{{ url_for('main.add_note', delivery_id=delivery.id) }}">
+          {{ note_form.hidden_tag() }}
+          <label class="form-label text-uppercase small text-secondary">Notiz</label>
+          {{ note_form.note_text(class_='form-control', rows=4, placeholder='Status, Hinweise...') }}
+          <button class="btn btn-warning w-100 mt-2" type="submit"><i class="bi bi-journal-text"></i> Notiz hinzufügen</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/tracker/templates/index.html
+++ b/tracker/templates/index.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% block title %}Scan | Liefer-Tracker{% endblock %}
+{% block content %}
+<div class="row g-4 align-items-stretch">
+  <div class="col-12 col-xl-6">
+    <div class="card bg-gradient-dark border border-warning h-100 shadow-lg">
+      <div class="card-body p-5">
+        <h1 class="display-5 text-warning fw-bold">Scan</h1>
+        <p class="lead text-secondary">Lieferscheinnummer einscannen oder eingeben und mit Enter bestätigen.</p>
+        <form method="post" action="{{ url_for('main.scan') }}" class="scan-form" autocomplete="off">
+          {{ form.hidden_tag() }}
+          <div class="mb-4">
+            {{ form.lieferscheinnummer.label(class_='form-label text-uppercase fw-semibold small text-secondary') }}
+            {{ form.lieferscheinnummer(class_='form-control form-control-lg text-monospace shadow-sm', placeholder='Lieferschein') }}
+          </div>
+          <div class="d-flex gap-3">
+            <button type="submit" class="btn btn-warning btn-lg px-5"><i class="bi bi-upc-scan"></i> {{ form.submit.label.text }}</button>
+            <button type="reset" class="btn btn-outline-light btn-lg" data-reset-scan><i class="bi bi-eraser"></i> Löschen</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-12 col-xl-6">
+    <div class="card bg-dark border border-secondary h-100 shadow">
+      <div class="card-body">
+        <h2 class="h4 text-uppercase text-warning mb-3"><i class="bi bi-diagram-3"></i> Aktive Stationen</h2>
+        <div class="station-grid">
+          {% for station in stations %}
+          <div class="station-card">
+            <div class="d-flex justify-content-between align-items-center mb-2">
+              <span class="badge bg-warning text-dark text-uppercase">{{ station.name }}</span>
+              {% if station.default_duration_hours %}
+              <span class="text-secondary small"><i class="bi bi-clock-history"></i> {{ station.default_duration_hours }} h</span>
+              {% endif %}
+            </div>
+            <div class="text-muted small station-info">{{ markdown_safe(station.info_text) | safe }}</div>
+          </div>
+          {% else %}
+          <p class="text-secondary">Keine aktiven Stationen.</p>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/tracker/templates/login.html
+++ b/tracker/templates/login.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="de" data-bs-theme="dark">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Login | Liefer-Tracker</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='app.css') }}">
+  </head>
+  <body class="bg-dark text-light d-flex align-items-center justify-content-center min-vh-100">
+    <div class="card bg-dark border border-warning shadow-lg" style="min-width: 360px;">
+      <div class="card-body p-5">
+        <h1 class="h4 text-uppercase text-warning mb-4"><i class="bi bi-box-seam"></i> Liefer-Tracker</h1>
+        <form method="post" action="{{ url_for('auth.login') }}">
+          {{ form.hidden_tag() }}
+          <div class="mb-3">
+            {{ form.username.label(class_='form-label text-uppercase small text-secondary') }}
+            {{ form.username(class_='form-control form-control-lg', placeholder='Benutzername', autofocus=True) }}
+          </div>
+          <div class="mb-4">
+            {{ form.device_label.label(class_='form-label text-uppercase small text-secondary') }}
+            {{ form.device_label(class_='form-control form-control-lg', placeholder='Gerät (optional)') }}
+          </div>
+          <button type="submit" class="btn btn-warning btn-lg w-100"><i class="bi bi-plug"></i> Anmelden</button>
+        </form>
+        {% with messages = get_flashed_messages(with_categories=True) %}
+        {% if messages %}
+        <div class="mt-4">
+          {% for category, message in messages %}
+          <div class="alert alert-{{ category }}" role="alert" data-flash-category="{{ category }}">{{ message }}</div>
+          {% endfor %}
+        </div>
+        {% endif %}
+        {% endwith %}
+      </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
+    <script src="{{ url_for('static', filename='app.js') }}"></script>
+  </body>
+</html>

--- a/tracker/templates/shipping_board.html
+++ b/tracker/templates/shipping_board.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+{% block title %}Versand | Liefer-Tracker{% endblock %}
+{% block content %}
+<div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-4">
+  <div>
+    <h1 class="h3 text-uppercase text-warning mb-1"><i class="bi bi-truck"></i> Versand & Prioritäten</h1>
+    <p class="text-secondary small">Sortiert nach Priorität, Versanddatum und Aktualität. Filter für Überfällig, Heute, Diese Woche oder spätere Termine.</p>
+  </div>
+  <div class="btn-group" role="group" aria-label="Scope">
+    <a class="btn btn-outline-warning {% if scope == 'all' %}active{% endif %}" href="{{ url_for('main.shipping_board', scope='all') }}">Alle</a>
+    <a class="btn btn-outline-warning {% if scope == 'overdue' %}active{% endif %}" href="{{ url_for('main.shipping_board', scope='overdue') }}">Überfällig</a>
+    <a class="btn btn-outline-warning {% if scope == 'today' %}active{% endif %}" href="{{ url_for('main.shipping_board', scope='today') }}">Heute</a>
+    <a class="btn btn-outline-warning {% if scope == 'week' %}active{% endif %}" href="{{ url_for('main.shipping_board', scope='week') }}">Diese Woche</a>
+    <a class="btn btn-outline-warning {% if scope == 'future' %}active{% endif %}" href="{{ url_for('main.shipping_board', scope='future') }}">Später</a>
+  </div>
+</div>
+
+<div class="d-flex justify-content-end mb-3">
+  <a class="btn btn-sm btn-outline-warning" href="{{ url_for('main.export_csv', scope=scope) }}"><i class="bi bi-download"></i> Export CSV</a>
+</div>
+
+<div class="card bg-dark border border-secondary shadow">
+  <div class="table-responsive">
+    <table class="table table-dark table-striped align-middle mb-0">
+      <thead class="text-uppercase small text-secondary">
+        <tr>
+          <th>#</th>
+          <th>Station</th>
+          <th>Versanddatum</th>
+          <th>KW</th>
+          <th>Priorität</th>
+          <th>Status</th>
+          <th>Aktualisiert</th>
+          {% if current_user and current_user.can_contribute() %}<th class="text-end">Aktionen</th>{% endif %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for delivery in deliveries %}
+        {% set due_status = determine_due_status(delivery) %}
+        {% set priority_label, priority_class = priority_badge(delivery.priority) %}
+        <tr>
+          <td class="text-monospace fw-semibold">{{ delivery.lieferscheinnummer }}</td>
+          <td>{% if delivery.current_station %}<span class="badge bg-warning text-dark">{{ delivery.current_station.name }}</span>{% else %}<span class="text-secondary">(keine)</span>{% endif %}</td>
+          <td>{% if delivery.ship_date %}<span class="badge {{ due_badge_class(due_status) }}">{{ delivery.ship_date.strftime('%d.%m.%Y') }}</span>{% else %}<span class="text-secondary">offen</span>{% endif %}</td>
+          <td>{{ delivery.shipping_week or '-' }}</td>
+          <td><span class="badge {{ priority_class }}">{{ priority_label }}</span></td>
+          <td>
+            {% if due_status == 'overdue' %}
+            <span class="text-danger fw-semibold"><i class="bi bi-exclamation-octagon"></i> Überfällig</span>
+            {% elif due_status == 'today' %}
+            <span class="text-warning fw-semibold"><i class="bi bi-sunrise"></i> Heute</span>
+            {% elif due_status == 'week' %}
+            <span class="text-info fw-semibold"><i class="bi bi-calendar-week"></i> Diese Woche</span>
+            {% else %}
+            <span class="text-secondary">Planbar</span>
+            {% endif %}
+          </td>
+          <td><span class="text-secondary small" title="{{ delivery.updated_at.isoformat() if delivery.updated_at else '' }}">{{ delivery.updated_at.strftime('%d.%m.%Y %H:%M') if delivery.updated_at else '' }}</span></td>
+          {% if current_user and current_user.can_contribute() %}
+          <td class="text-end">
+            <div class="btn-group btn-group-sm flex-wrap justify-content-end" role="group">
+              <a class="btn btn-outline-warning" href="{{ url_for('main.delivery_detail', delivery_id=delivery.id) }}"><i class="bi bi-box-arrow-in-right"></i></a>
+              <form method="post" action="{{ url_for('main.set_priority', delivery_id=delivery.id) }}" class="d-inline">
+                {{ csrf_token() }}
+                {% set next_priority = delivery.priority + 1 if delivery.priority < 2 else 2 %}
+                <input type="hidden" name="priority" value="{{ next_priority }}">
+                <button class="btn btn-outline-warning" type="submit" title="Priorität erhöhen"><i class="bi bi-arrow-up"></i></button>
+              </form>
+              <form method="post" action="{{ url_for('main.set_ship_date', delivery_id=delivery.id) }}" class="d-inline">
+                {{ csrf_token() }}
+                <input type="hidden" name="ship_date" value="{{ today.isoformat() }}">
+                <button class="btn btn-outline-warning" type="submit" title="Heute versenden"><i class="bi bi-calendar-day"></i></button>
+              </form>
+              <form method="post" action="{{ url_for('main.set_station', delivery_id=delivery.id) }}" class="d-inline">
+                {{ csrf_token() }}
+                <select name="station_id" class="form-select form-select-sm d-inline-block w-auto">
+                  {% for station in stations %}
+                  <option value="{{ station.id }}" {% if delivery.current_station_id == station.id %}selected{% endif %}>{{ station.name }}</option>
+                  {% endfor %}
+                </select>
+                <button class="btn btn-warning" type="submit" title="Station setzen"><i class="bi bi-diagram-3"></i></button>
+              </form>
+            </div>
+          </td>
+          {% endif %}
+        </tr>
+        {% else %}
+        <tr>
+          <td colspan="{% if current_user and current_user.can_contribute() %}8{% else %}7{% endif %}" class="text-center text-secondary py-5">Keine Lieferungen im gewählten Filter.</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/tracker/utils.py
+++ b/tracker/utils.py
@@ -1,0 +1,109 @@
+"""Utility helpers for the delivery tracker."""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from functools import wraps
+from typing import Callable, Iterable, Optional
+
+import bleach
+import markdown
+from flask import abort, flash, g, redirect, url_for
+
+from .models import Delivery, Role, Station
+
+ALLOWED_MARKDOWN_TAGS = [
+    "p",
+    "strong",
+    "em",
+    "ul",
+    "ol",
+    "li",
+    "br",
+    "code",
+    "pre",
+    "blockquote",
+    "a",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+]
+ALLOWED_MARKDOWN_ATTRS = {
+    "a": ["href", "title", "rel"],
+}
+
+
+def markdown_safe(text: Optional[str]) -> str:
+    """Render markdown-like text safely with limited tags."""
+    if not text:
+        return ""
+    html = markdown.markdown(text, extensions=["extra", "sane_lists"])
+    return bleach.clean(html, tags=ALLOWED_MARKDOWN_TAGS, attributes=ALLOWED_MARKDOWN_ATTRS, strip=True)
+
+
+def role_required(*roles: Role) -> Callable:
+    """Ensure the current user has at least one of the given roles."""
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            user = getattr(g, "current_user", None)
+            if user is None:
+                flash("Login erforderlich", "danger")
+                return redirect(url_for("auth.login"))
+            if roles and user.role not in roles:
+                abort(403)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def iso_week(value: date) -> int:
+    return value.isocalendar().week
+
+
+def determine_due_status(delivery: Delivery) -> Optional[str]:
+    """Return textual due status for UI display."""
+    if not delivery.ship_date:
+        return None
+    today = date.today()
+    if delivery.ship_date < today:
+        if delivery.current_station and delivery.current_station.name == "Versand abgeschlossen":
+            return None
+        return "overdue"
+    if delivery.ship_date == today:
+        return "today"
+    if delivery.shipping_week == today.isocalendar().week:
+        return "week"
+    return "future"
+
+
+def due_badge_class(status: Optional[str]) -> str:
+    return {
+        "overdue": "bg-danger",
+        "today": "bg-warning text-dark",
+        "week": "bg-info text-dark",
+    }.get(status or "", "bg-secondary")
+
+
+def priority_badge(priority: int) -> tuple[str, str]:
+    mapping = {
+        0: ("Normal", "bg-secondary"),
+        1: ("Hoch", "bg-warning text-dark"),
+        2: ("Kritisch", "bg-danger"),
+    }
+    return mapping.get(priority, (f"Priorität {priority}", "bg-secondary"))
+
+
+def eta_for_station(station: Optional[Station]) -> Optional[datetime]:
+    if station and station.default_duration_hours:
+        return datetime.utcnow() + timedelta(hours=station.default_duration_hours)
+    return None
+
+
+def pagination_range(page: int, pages: int, span: int = 3) -> Iterable[int]:
+    start = max(1, page - span)
+    end = min(pages, page + span)
+    return range(start, end + 1)


### PR DESCRIPTION
## Summary
- create a Flask-based delivery tracker with login-by-username, device tokens, and role-aware views
- add dark industrial Bootstrap UI including scanning, delivery management, shipping board, and CSV export
- provide admin CRUD for stations, users, and devices plus project README and styling assets

## Testing
- python3 -m compileall tracker

------
https://chatgpt.com/codex/tasks/task_e_68dfef7795c4832eba5739eaf9970bda